### PR TITLE
Remove polyfill.io reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
 		<script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.js"></script>
 		<script type="text/javascript" src="https://cdn.datatables.net/v/dt/jqc-1.12.4/dt-1.12.1/b-2.2.3/sl-1.4.0/datatables.min.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>	
-		<script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>  
 
 		<script>
 			async function getSearchResults(query) {


### PR DESCRIPTION
The polyfills are not needed in any modern browser.  If something is still needed (I'm just removing the line, not testing all the code), there are other polyfill options available.

https://www.sonatype.com/blog/polyfill.io-supply-chain-attack-hits-100000-websites-all-you-need-to-know